### PR TITLE
Adding hourly forecast feature & default temperature behavior

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 const { Command } = require('commander');
 const program = new Command();
-const { currentTemperature } = require('../lib/index');
 const { temperatureSelector } = require('../lib/index');
 const package = require('../package.json');
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 const { Command } = require('commander');
-const program = new Command();
 const { temperatureSelector } = require('../lib/index');
 const package = require('../package.json');
+
+const program = new Command();
 
 program
   .name(package.name)

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,7 +13,8 @@ program
 program.command('temperature')
   .description('Shows temperature information according the parameters provided')
   .argument('<city>', 'Name of the desired city. For cities which name has more than one word please use "" !')
-  .option('-c, --current', 'to obtain current information for this city')
+  .option('--hourly', 'Provides hourly temperature forecast for the informed city')
+  .option('-c, --current', 'Provides current information for this city')
   .action(async (args, options) => {
     console.log(await temperatureSelector(args, options));
   })

--- a/lib/currentTemperature.js
+++ b/lib/currentTemperature.js
@@ -12,9 +12,9 @@ async function currentTemperature(city) {
             headers: {}
         };
 
-        const response = await axios.request(config);
+        const { data: { current }} = await axios.request(config);
 
-        return `The current temperature at ${city}, state of ${state} in ${country} is ${response.data.current.temperature_2m} ºC`;
+        return `The current temperature at ${city}, state of ${state} in ${country} is ${current.temperature_2m} ºC`;
     } catch (error) {
         throw error;
     }

--- a/lib/functionSelector.js
+++ b/lib/functionSelector.js
@@ -1,8 +1,13 @@
 const { currentTemperature } = require('./currentTemperature');
+const { hourlyTemperature } = require('./hourlyTemperature');
 
 async function temperatureSelector (args, options ) { 
     if (options.current) {
         return await currentTemperature(args);
+    }
+
+    if(options.hourly) {
+        return await hourlyTemperature(args);
     }
 }
 

--- a/lib/functionSelector.js
+++ b/lib/functionSelector.js
@@ -9,6 +9,8 @@ async function temperatureSelector (args, options ) {
     if(options.hourly) {
         return await hourlyTemperature(args);
     }
+
+    return await currentTemperature(args);
 }
 
 module.exports.temperatureSelector = temperatureSelector;

--- a/lib/hourlyTemperature.js
+++ b/lib/hourlyTemperature.js
@@ -1,0 +1,36 @@
+const axios = require('axios');
+const { findCoordinates } = require('./findCoordinates');
+
+function formatedTemperatureForecast(time, temperature) {
+    let finalForecastString = "";
+
+    for (let i = 0; i < time.length; i++) {
+        finalForecastString += "\n" + `${time[i]} -> ${temperature[i]} ºC`;
+    }
+
+    return finalForecastString;
+}
+
+async function hourlyTemperature(city) {
+    try {
+        const { country, state, latitude, longitude } = await findCoordinates(city);
+
+        let config = {
+            method: 'get',
+            maxBodyLength: Infinity,
+            url: `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=temperature_2m&forecast_hours=12&timezone=auto`,
+            headers: {}
+        };
+
+        const { data: { hourly: { time, temperature_2m: temperature } } } = await axios.request(config);
+
+        return `The hourly temperature forecast for the city of ${city}, state of ${state}, in ${country} in the next 12 hours will be:` 
+        + formatedTemperatureForecast(time, temperature);
+    } catch (error) {
+        console.error(`Failed to obtain hourly temperature forecast - error: ${error}`);
+    }
+}
+
+hourlyTemperature("Campinas");
+
+module.exports.hourlyTemperature = hourlyTemperature;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "A simple CLI based on Node JS to show in the terminal weather information",
   "main": "bin/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A simple CLI based on Node JS to show in the terminal weather information",
   "main": "bin/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A simple CLI based on Node JS to show in the terminal weather information",
   "main": "bin/index.js",
   "type": "commonjs",

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,9 @@ weather temperature --current "city name"
 ```
 
 It will try to obtain the approximated coordinates by searching the name of the given city at the geo coding api of Open-Meteo, then it will use the latitude and longitude data to obtain the current temperature using the weather api of Open-Meteo as well.
+
+- Hourly forecast: It can provide a 12 hour forecast of the temperature for a given city name
+
+```
+weather temperature --hourly "city name"
+```

--- a/readme.md
+++ b/readme.md
@@ -21,3 +21,9 @@ It will try to obtain the approximated coordinates by searching the name of the 
 ```
 weather temperature --hourly "city name"
 ```
+
+- Default behavior: It currently defaults to show the current temperature, subject to change soon
+
+```
+weather temperature "city name"
+```


### PR DESCRIPTION
A new feature is added, hourly forecast, enabling request the next 12 hours temperature forecast for a given city.

```
weather temperature --hourly <city name>
```

A default behavior is also added for the temperature command, it defaults to the current temperature now:
```
weather temperature <city name>
```